### PR TITLE
Bug/issue 51 escaped chars stripped

### DIFF
--- a/src/EntryPoint/EntryPoint.csproj
+++ b/src/EntryPoint/EntryPoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Lightweight and Composable CLI Argument Parser for all modern .Net platforms</Description>
     <AssemblyTitle>EntryPoint</AssemblyTitle>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.2.3</VersionPrefix>
     <Authors>Nick Lucas</Authors>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
     <AssemblyName>EntryPoint</AssemblyName>

--- a/src/EntryPoint/Parsing/Tokeniser.cs
+++ b/src/EntryPoint/Parsing/Tokeniser.cs
@@ -51,11 +51,10 @@ namespace EntryPoint.Parsing {
 
         static IEnumerable<Token> BasicTokenise(string args) {
             bool isOption = false;
-            bool escaped = false;
 
             StringBuilder token = new StringBuilder();
             List<Token> tokens = new List<Token>();
-            Action StoreToken = () => {
+            void StoreToken() {
                 if (token.Length > 0) {
                     var t = token.ToString().Trim('"');
                     tokens.Add(new Token(t, isOption));
@@ -65,30 +64,19 @@ namespace EntryPoint.Parsing {
             };
 
             foreach (var c in args.ToCharArray()) {
-                if (!escaped && c == '\\') {
-                    // If char is an unescaped escape, then set the escape state and continue
-                    escaped = true;
-                    continue;
-                }
-
-                if (!escaped && (c == '=')) {
-                    // if char is an unescaped = then store the token and start again
+                if (c == '=') {
+                    // if char is = then store the token and start again
                     // Whitespace splitting was already handled by .Net
                     StoreToken();
 
                 } else {
-                    if (!escaped && token.Length == 0 && c == '-') {
+                    if (token.Length == 0 && c == '-') {
                         // Mark the new token as an option
                         isOption = true;
                     }
 
-                    // Otherwise append thiss char to the current token
+                    // Otherwise append this char to the current token
                     token.Append(c);
-                }
-
-                if (escaped) {
-                    // If this char was escape then switch off for the next char
-                    escaped = false;
                 }
             }
             StoreToken();

--- a/test/EntryPointTests/ParsingTests/TokeniserTests.cs
+++ b/test/EntryPointTests/ParsingTests/TokeniserTests.cs
@@ -9,37 +9,13 @@ using EntryPoint.Parsing;
 namespace EntryPointTests.ParsingTests {
     public class TokeniserTests {
 
-        [Fact]
-        public void Tokenise_EscaleSingleDash() {
-            string[] args = new string[] { "--hello", @"\-world" };
-            List<Token> expectedTokens = new List<Token>() {
-                new Token("--hello", true),
-                new Token("-world", false)
-            };
-
-            var tokens = Tokeniser.MakeTokens(args);
-            Assert.Equal(expectedTokens, tokens, new TokenEqualityComparer());
-        }
-
-        [Fact]
-        public void Tokenise_EscapeNonQuotedArg() {
-            string[] args = new string[] { "--hello", @"\--world" };
-            List<Token> expectedTokens = new List<Token>() {
-                new Token("--hello", true),
-                new Token(@"\--world", false)
-            };
-
-            var tokens = Tokeniser.MakeTokens(args);
-            Assert.Equal(expectedTokens, tokens, new TokenEqualityComparer());
-        }
-
-        // the whole world argument is in quotes here
+        // this text would be received if the user passed the argument in quotes (quotes would be stripped)
         [Fact]
         public void Tokenise_EscapeQuotedArg() {
-            string[] args = new string[] { "--hello", "\"--w\\orld\"" };
+            string[] args = new string[] { "--hello", @"w\orld" };
             List<Token> expectedTokens = new List<Token>() {
                 new Token("--hello", true),
-                new Token("--world", false)
+                new Token(@"w\orld", false)
             };
 
             var tokens = Tokeniser.MakeTokens(args);

--- a/test/EntryPointTests/ParsingTests/TokeniserTests.cs
+++ b/test/EntryPointTests/ParsingTests/TokeniserTests.cs
@@ -22,11 +22,21 @@ namespace EntryPointTests.ParsingTests {
         }
 
         [Fact]
-        // TODO: revise this behaviour, it's correct and understood
-        // TODO: but maybe there is a precedent for having to escape
-        // TODO: both dashes to see a potential option as a parameter?
-        public void Tokenise_EscapeDoubleDash() {
+        public void Tokenise_EscapeNonQuotedArg() {
             string[] args = new string[] { "--hello", @"\--world" };
+            List<Token> expectedTokens = new List<Token>() {
+                new Token("--hello", true),
+                new Token(@"\--world", false)
+            };
+
+            var tokens = Tokeniser.MakeTokens(args);
+            Assert.Equal(expectedTokens, tokens, new TokenEqualityComparer());
+        }
+
+        // the whole world argument is in quotes here
+        [Fact]
+        public void Tokenise_EscapeQuotedArg() {
+            string[] args = new string[] { "--hello", "\"--w\\orld\"" };
             List<Token> expectedTokens = new List<Token>() {
                 new Token("--hello", true),
                 new Token("--world", false)


### PR DESCRIPTION
Fixes #51 

The problem was an early assumption made during the Tokeniser's development, which has wider reaching impacts than thought.

This is potentially a breaking change, but I don't believe anyone would take advantage of the existing behaviour, and it's more likely to have caused bugs/pain for users.

In effect we were supporting the following: `app --path \-value-of-path`, and this support was causing issues due to a simplistic implementation.

Actual best practice would be to pass `app --path "-value-of-path"` instead, though quotes get stripped by the shell, so this is impossible to support (see below comment)